### PR TITLE
Mapping table 틀(?) 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,22 @@ services:
     command: --lower_case_table_names=1
     restart: always
     environment:
-      MYSQL_DATABASE: 'hapi'
-      MYSQL_USER: 'admin'
-      MYSQL_PASSWORD: 'admin'
-      MYSQL_ROOT_PASSWORD: 'admin'
+      MYSQL_DATABASE: "hapi"
+      MYSQL_USER: "admin"
+      MYSQL_PASSWORD: "admin"
+      MYSQL_ROOT_PASSWORD: "admin"
     volumes:
       - hapi-fhir-mysql:/var/lib/mysql
+  hapi-fhir-postgres:
+    image: postgres:latest
+    container_name: hapi-fhir-postgres
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - ":5432"
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "admin"
+      POSTGRES_DB: "poc"
 volumes:
   hapi-fhir-mysql:

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,30 @@
+CREATE TABLE Patient (
+  id VARCHAR(50),
+  PatientGender VARCHAR(50),
+  PatientDateOfBirth VARCHAR(50),
+  PatientRace VARCHAR(50),
+  PatientMaritalStatus VARCHAR(50),
+  PatientLanguage VARCHAR(50),
+  PatientPopulationPercentageBelowPoverty decimal,
+  deleted BOOLEAN DEFAULT false,
+  emr BOOLEAN DEFAULT false,
+  fhir BOOLEAN DEFAULT false,
+	version SERIAL
+);
+
+ALTER SEQUENCE public.patient_version_seq CYCLE;
+
+CREATE OR REPLACE FUNCTION update_modified_column()
+RETURNS TRIGGER AS $$
+BEGIN                                          
+  if (NEW.emr = true) OR
+      (NEW.fhir = true) then
+    NEW.version := nextval(pg_get_serial_sequence('public.patient', 'version'));
+  end if;
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_modtime BEFORE UPDATE ON Patient FOR EACH ROW EXECUTE PROCEDURE  update_modified_column();
+
+CREATE UNIQUE INDEX idx_patient_id ON Patient(id);

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+          <groupId>com.googlecode.json-simple</groupId>
+          <artifactId>json-simple</artifactId>
+          <version>1.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -40,6 +40,8 @@ import ca.uhn.fhir.jpa.search.StaleSearchDeletingSvcImpl;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.annotations.OnImplementationGuidesPresent;
 import ca.uhn.fhir.jpa.starter.common.validation.IRepositoryValidationInterceptorFactory;
+import ca.uhn.fhir.jpa.starter.interceptors.PullDataInterceptor;
+import ca.uhn.fhir.jpa.starter.interceptors.PushDataInterceptor;
 import ca.uhn.fhir.jpa.starter.util.EnvironmentHelper;
 import ca.uhn.fhir.jpa.subscription.util.SubscriptionDebugLogInterceptor;
 import ca.uhn.fhir.jpa.util.ResourceCountCache;
@@ -245,7 +247,7 @@ public class StarterJpaConfig {
 	}
 
 	@Bean
-	public RestfulServer restfulServer(IFhirSystemDao<?, ?> fhirSystemDao, AppProperties appProperties, DaoRegistry daoRegistry, Optional<MdmProviderLoader> mdmProviderProvider, IJpaSystemProvider jpaSystemProvider, ResourceProviderFactory resourceProviderFactory, DaoConfig daoConfig, ISearchParamRegistry searchParamRegistry, IValidationSupport theValidationSupport, DatabaseBackedPagingProvider databaseBackedPagingProvider, LoggingInterceptor loggingInterceptor, Optional<TerminologyUploaderProvider> terminologyUploaderProvider, Optional<SubscriptionTriggeringProvider> subscriptionTriggeringProvider, Optional<CorsInterceptor> corsInterceptor, IInterceptorBroadcaster interceptorBroadcaster, Optional<BinaryAccessProvider> binaryAccessProvider, BinaryStorageInterceptor binaryStorageInterceptor, IValidatorModule validatorModule, Optional<GraphQLProvider> graphQLProvider, BulkDataExportProvider bulkDataExportProvider, BulkDataImportProvider bulkDataImportProvider, ValueSetOperationProvider theValueSetOperationProvider, ReindexProvider reindexProvider, PartitionManagementProvider partitionManagementProvider, Optional<RepositoryValidatingInterceptor> repositoryValidatingInterceptor, IPackageInstallerSvc packageInstallerSvc) {
+	public RestfulServer restfulServer(IFhirSystemDao<?, ?> fhirSystemDao, AppProperties appProperties, DaoRegistry daoRegistry, Optional<MdmProviderLoader> mdmProviderProvider, IJpaSystemProvider jpaSystemProvider, ResourceProviderFactory resourceProviderFactory, DaoConfig daoConfig, ISearchParamRegistry searchParamRegistry, IValidationSupport theValidationSupport, DatabaseBackedPagingProvider databaseBackedPagingProvider, LoggingInterceptor loggingInterceptor, Optional<TerminologyUploaderProvider> terminologyUploaderProvider, Optional<SubscriptionTriggeringProvider> subscriptionTriggeringProvider, Optional<CorsInterceptor> corsInterceptor, IInterceptorBroadcaster interceptorBroadcaster, Optional<BinaryAccessProvider> binaryAccessProvider, BinaryStorageInterceptor binaryStorageInterceptor, IValidatorModule validatorModule, Optional<GraphQLProvider> graphQLProvider, BulkDataExportProvider bulkDataExportProvider, BulkDataImportProvider bulkDataImportProvider, ValueSetOperationProvider theValueSetOperationProvider, ReindexProvider reindexProvider, PartitionManagementProvider partitionManagementProvider, Optional<RepositoryValidatingInterceptor> repositoryValidatingInterceptor, IPackageInstallerSvc packageInstallerSvc, PushDataInterceptor pushDataInterceptor, PullDataInterceptor pullDataInterceptor) {
 		RestfulServer fhirServer = new RestfulServer(fhirSystemDao.getContext());
 
 
@@ -417,6 +419,9 @@ public class StarterJpaConfig {
 		repositoryValidatingInterceptor.ifPresent(fhirServer::registerInterceptor);
 
 
+    /* push / pull data interceptor */
+    fhirServer.registerInterceptor(pushDataInterceptor);
+    fhirServer.registerInterceptor(pullDataInterceptor);
 
 		return fhirServer;
 	}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/AbortDatabaseOperationException.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/AbortDatabaseOperationException.java
@@ -1,0 +1,5 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+public class AbortDatabaseOperationException extends RuntimeException {
+  public AbortDatabaseOperationException() {}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
@@ -71,7 +71,7 @@ public class PullDataInterceptor {
 
       if (req.getMethod().equals(HttpMethod.GET.toString())) {
         /* 3 Delete Mapping table */
-        String deleteSql = String.format("DELETE FROM %s WHERE ts <= ? AND emr = true", resourceName);
+        String deleteSql = String.format("DELETE FROM %s WHERE ts <= ? AND emr = true AND fhir = false", resourceName);
         PreparedStatement deleteStat = conn.prepareStatement(deleteSql);
         deleteStat.setTimestamp(1, latest);
         deleteStat.executeUpdate();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
@@ -4,7 +4,6 @@ import java.sql.Timestamp;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.sql.DataSource;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
@@ -21,6 +21,7 @@ import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.starter.mappers.IResourceMapper;
 import ca.uhn.fhir.jpa.starter.mappers.ResourceMapperRegistry;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 
 @Component
 @Interceptor
@@ -42,10 +43,9 @@ public class PullDataInterceptor {
     this.mapperRegistry = mapperRegistry;
   }
 
-  @Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
-  public boolean pullDataBeforeRequest(HttpServletRequest req, HttpServletResponse resp) {
-    String resourceName = req.getRequestURI().split("/")[2];
-
+  @Hook(Pointcut.SERVER_INCOMING_REQUEST_POST_PROCESSED)
+  public boolean pullDataBeforeRequest(RequestDetails details, HttpServletRequest req, HttpServletResponse resp) {
+    String resourceName = details.getResourceName();
 
     try {
       /* 1 Pull mapping table */

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
@@ -1,0 +1,79 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.starter.mappers.IResourceMapper;
+import ca.uhn.fhir.jpa.starter.mappers.ResourceMapperRegistry;
+
+@Component
+@Interceptor
+public class PullDataInterceptor {
+  private String connectionString;
+  private DaoRegistry daoRegistry;
+  private ResourceMapperRegistry mapperRegistry;
+
+  public PullDataInterceptor(@Value("${mappingtable.jdbc}") String connectionString, DaoRegistry daoRegistry, ResourceMapperRegistry mapperRegistry) {
+    this.connectionString = connectionString;
+    this.daoRegistry = daoRegistry;
+    this.mapperRegistry = mapperRegistry;
+  }
+
+  @Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
+  public boolean pullDataBeforeRequest(HttpServletRequest req, HttpServletResponse resp) {
+    String resourceName = req.getContextPath().substring(1);
+    String selectSql = String.format("SELECT * FROM %s;", resourceName);
+    try (Connection conn = DriverManager.getConnection(connectionString)) {
+      /* 1 Pull mapping table */
+      PreparedStatement stat = conn.prepareStatement(selectSql);
+      ResultSet result = stat.executeQuery();
+
+      /* 2 Update Fhir Database using DAO and Mapper */
+      IFhirResourceDao<IBaseResource> dao = daoRegistry.getResourceDao(resourceName);
+      IResourceMapper mapper = mapperRegistry.getMapper(resourceName);
+      Date latest = null; /* Remember latest timestamp reflected */
+      while (result.next()) {
+        Date timestamp = result.getDate("ts");
+        if (latest == null || latest.before(timestamp)) {
+          latest = timestamp;
+        }
+
+        boolean deleteFlag = result.getBoolean("deleted");
+        IBaseResource resource = mapper.mapToResource(result);
+        if (deleteFlag) {
+          dao.delete(resource.getIdElement());
+        } else {
+          dao.update(resource);
+        }
+      }
+
+      if (req.getMethod().equals(HttpMethod.GET.toString())) {
+        /* 3 Delete Mapping table */
+        String deleteSql = String.format("DELETE FROM %s WHERE ts < ?", resourceName);
+        PreparedStatement deleteStat = conn.prepareStatement(deleteSql);
+        deleteStat.setDate(1, latest);
+        deleteStat.executeUpdate();
+      }
+      return true;
+    } catch (SQLException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
@@ -39,7 +39,7 @@ public class PullDataInterceptor {
   @Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
   public boolean pullDataBeforeRequest(HttpServletRequest req, HttpServletResponse resp) {
     String resourceName = req.getContextPath().substring(1);
-    String selectSql = String.format("SELECT * FROM %s;", resourceName);
+    String selectSql = String.format("SELECT * FROM %s WHERE emr = true;", resourceName);
     try (Connection conn = DriverManager.getConnection(connectionString)) {
       /* 1 Pull mapping table */
       PreparedStatement stat = conn.prepareStatement(selectSql);
@@ -66,7 +66,7 @@ public class PullDataInterceptor {
 
       if (req.getMethod().equals(HttpMethod.GET.toString())) {
         /* 3 Delete Mapping table */
-        String deleteSql = String.format("DELETE FROM %s WHERE ts < ?", resourceName);
+        String deleteSql = String.format("DELETE FROM %s WHERE ts < ? AND emr = true", resourceName);
         PreparedStatement deleteStat = conn.prepareStatement(deleteSql);
         deleteStat.setDate(1, latest);
         deleteStat.executeUpdate();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -1,18 +1,26 @@
 package ca.uhn.fhir.jpa.starter.interceptors;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.sql.DataSource;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.PreparedStatementCallback;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.stereotype.Component;
 
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
-import ca.uhn.fhir.jpa.starter.mappers.DatabaseOperation;
 import ca.uhn.fhir.jpa.starter.mappers.IResourceMapper;
 import ca.uhn.fhir.jpa.starter.mappers.ResourceMapperRegistry;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
@@ -20,59 +28,79 @@ import ca.uhn.fhir.rest.api.server.RequestDetails;
 @Component
 @Interceptor
 public class PushDataInterceptor {
-  private String connectionString;
-  private String username;
-  private String password;
+  private NamedParameterJdbcTemplate jdbcTemplate;
   private ResourceMapperRegistry mapperRegistry;
 
   public PushDataInterceptor(@Value("${mappingtable.jdbc}") String connectionString,
       @Value("${mappingtable.username}") String username, @Value("${mappingtable.password}") String password,
-      ResourceMapperRegistry mapperRegistry) {
-    this.connectionString = connectionString;
-    this.username = username;
-    this.password = password;
+      @Value("${mappingtable.driver}") String driver, ResourceMapperRegistry mapperRegistry) {
+    DriverManagerDataSource dataSource = new DriverManagerDataSource();
+    dataSource.setUrl(connectionString);
+    dataSource.setUsername(username);
+    dataSource.setPassword(password);
+    dataSource.setDriverClassName(driver);
+    this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
     this.mapperRegistry = mapperRegistry;
+  }
+
+  private String insertQuery(String resourceName, List<String> columns, boolean deleted) {
+    List<String> columnValue = columns.stream().map(name -> String.format(":%s", name)).collect(Collectors.toList());
+    return String.format("INSERT INTO %s (%s, fhir, deleted) VALUES (%s, true, %s)", resourceName,
+        String.join(",", columns), String.join(",", columnValue), deleted);
+  }
+
+  private String upsertQuery(String resourceName, List<String> columns, boolean deleted) {
+    String insertQuery = insertQuery(resourceName, columns, deleted);
+    String setter = String.join(",", columns.stream().map(param -> String.format("%s = :%s", param, param)).collect(Collectors.toList()));
+    String updateQuery = String.format("UPDATE SET %s, deleted = %s, fhir = true WHERE Patient.ts = :ts", setter, deleted);
+    return String.format("%s ON CONFLICT (id) DO %s", insertQuery, updateQuery);
+  }
+
+  private void execute(String query, SqlParameterSource parameters) {
+    jdbcTemplate.execute(query, parameters, new PreparedStatementCallback() {
+      @Override
+      public Object doInPreparedStatement(PreparedStatement ps)
+          throws SQLException, DataAccessException {
+        return ps.executeUpdate();
+      }
+    });
   }
 
   @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
   public void pushCreateData(IBaseResource resource, RequestDetails details) {
+    String resourceName = details.getResourceName();
     /* Push to mapping table */
-    try (Connection conn = DriverManager.getConnection(connectionString, username, password)) {
-      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
-      String sql = mapper.mapToTable(resource, DatabaseOperation.INSERT);
-      PreparedStatement stat = conn.prepareStatement(sql);
-      stat.executeUpdate();
-    } catch (SQLException e) {
-      e.printStackTrace();
+    IResourceMapper mapper = mapperRegistry.getMapper(resourceName);
+    SqlParameterSource parameters = mapper.mapToTable(resource);
+    if (!resource.getIdElement().hasIdPart()) {
+      List<String> columnNameWithoutId = Arrays.stream(parameters.getParameterNames())
+          .filter(param -> !param.equals("id")).collect(Collectors.toList());
+      String queryString = insertQuery(resourceName, columnNameWithoutId, false);
+      System.out.println(queryString);
+      execute(insertQuery(resourceName, columnNameWithoutId, false), parameters);
+    } else {
+      execute(upsertQuery(resourceName, List.of(parameters.getParameterNames()), false), parameters);
     }
     throw new AbortDatabaseOperationException();
   }
 
   @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
   public void pushUpdateData(IBaseResource resource, RequestDetails details) {
+    String resourceName = details.getResourceName();
     /* Push to mapping table */
-    try (Connection conn = DriverManager.getConnection(connectionString, username, password)) {
-      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
-      String sql = mapper.mapToTable(resource, DatabaseOperation.UPDATE);
-      PreparedStatement stat = conn.prepareStatement(sql);
-      stat.executeUpdate();
-    } catch (SQLException e) {
-      e.printStackTrace();
-    }
+    IResourceMapper mapper = mapperRegistry.getMapper(resourceName);
+    SqlParameterSource parameters = mapper.mapToTable(resource);
+    execute(upsertQuery(resourceName, List.of(parameters.getParameterNames()), false), parameters);
     throw new AbortDatabaseOperationException();
   }
 
   @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_DELETED)
   public void pushDeleteData(IBaseResource resource, RequestDetails details) {
+    String resourceName = details.getResourceName();
     /* Push to mapping table */
-    try (Connection conn = DriverManager.getConnection(connectionString, username, password)) {
-      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
-      String sql = mapper.mapToTable(resource, DatabaseOperation.DELETE);
-      PreparedStatement stat = conn.prepareStatement(sql);
-      stat.executeUpdate();
-    } catch (SQLException e) {
-      e.printStackTrace();
-    }
+    IResourceMapper mapper = mapperRegistry.getMapper(resourceName);
+    SqlParameterSource parameters = mapper.mapToTable(resource);
+    execute(upsertQuery(resourceName, List.of(parameters.getParameterNames()), true), parameters);
     throw new AbortDatabaseOperationException();
   }
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -76,7 +76,6 @@ public class PushDataInterceptor {
       List<String> columnNameWithoutId = Arrays.stream(parameters.getParameterNames())
           .filter(param -> !param.equals("id")).collect(Collectors.toList());
       String queryString = insertQuery(resourceName, columnNameWithoutId, false);
-      System.out.println(queryString);
       execute(insertQuery(resourceName, columnNameWithoutId, false), parameters);
     } else {
       execute(upsertQuery(resourceName, List.of(parameters.getParameterNames()), false), parameters);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -42,7 +42,7 @@ public class PushDataInterceptor {
 
   private String insertQuery(String resourceName, List<String> columns, boolean deleted) {
     List<String> columnValue = columns.stream().map(name -> String.format(":%s", name)).collect(Collectors.toList());
-    return String.format("INSERT INTO %s (%s, fhir, deleted) VALUES (%s, true, %s)", resourceName,
+    return String.format("INSERT INTO %s (%s, emr, fhir, deleted) VALUES (%s, false, true, %s)", resourceName,
         String.join(",", columns), String.join(",", columnValue), deleted);
   }
 
@@ -50,7 +50,9 @@ public class PushDataInterceptor {
     String insertQuery = insertQuery(resourceName, columns, deleted);
     String setter = String.join(",",
         columns.stream().map(param -> String.format("%s = :%s", param, param)).collect(Collectors.toList()));
-    String updateQuery = String.format("UPDATE SET %s, deleted = %s, fhir = true WHERE Patient.ts = :ts", setter,
+    // TODO: Resource.ts cannot be used as unique key in DB
+    String updateQuery = String.format("UPDATE SET %s, deleted = %s, emr = false, fhir = true WHERE Patient.ts = :ts",
+        setter,
         deleted);
     return String.format("%s ON CONFLICT (id) DO %s", insertQuery, updateQuery);
   }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -50,8 +50,8 @@ public class PushDataInterceptor {
     String insertQuery = insertQuery(resourceName, columns, deleted);
     String setter = String.join(",",
         columns.stream().map(param -> String.format("%s = :%s", param, param)).collect(Collectors.toList()));
-    // TODO: Resource.ts cannot be used as unique key in DB
-    String updateQuery = String.format("UPDATE SET %s, deleted = %s, emr = false, fhir = true WHERE Patient.ts = :ts",
+    String updateQuery = String.format(
+        "UPDATE SET %s, deleted = %s, emr = false, fhir = true WHERE Patient.version = :version",
         setter,
         deleted);
     return String.format("%s ON CONFLICT (id) DO %s", insertQuery, updateQuery);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -1,85 +1,28 @@
 package ca.uhn.fhir.jpa.starter.interceptors;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.core.PreparedStatementCallback;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.stereotype.Component;
 
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
-import ca.uhn.fhir.jpa.starter.mappers.IResourceMapper;
-import ca.uhn.fhir.jpa.starter.mappers.ResourceMapperRegistry;
+import ca.uhn.fhir.jpa.starter.mappers.MappingTableManager;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 
 @Component
 @Interceptor
 public class PushDataInterceptor {
-  private NamedParameterJdbcTemplate jdbcTemplate;
-  private ResourceMapperRegistry mapperRegistry;
+  private MappingTableManager manager;
 
-  public PushDataInterceptor(@Value("${mappingtable.jdbc}") String connectionString,
-      @Value("${mappingtable.username}") String username, @Value("${mappingtable.password}") String password,
-      @Value("${mappingtable.driver}") String driver, ResourceMapperRegistry mapperRegistry) {
-    DriverManagerDataSource dataSource = new DriverManagerDataSource();
-    dataSource.setUrl(connectionString);
-    dataSource.setUsername(username);
-    dataSource.setPassword(password);
-    dataSource.setDriverClassName(driver);
-    this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
-    this.mapperRegistry = mapperRegistry;
-  }
-
-  private String insertQuery(String resourceName, List<String> columns, boolean deleted) {
-    List<String> columnValue = columns.stream().map(name -> String.format(":%s", name)).collect(Collectors.toList());
-    return String.format("INSERT INTO %s (%s, emr, fhir, deleted) VALUES (%s, false, true, %s)", resourceName,
-        String.join(",", columns), String.join(",", columnValue), deleted);
-  }
-
-  private String upsertQuery(String resourceName, List<String> columns, boolean deleted) {
-    String insertQuery = insertQuery(resourceName, columns, deleted);
-    String setter = String.join(",",
-        columns.stream().map(param -> String.format("%s = :%s", param, param)).collect(Collectors.toList()));
-    // TODO: Resource.ts cannot be used as unique key in DB
-    String updateQuery = String.format("UPDATE SET %s, deleted = %s, emr = false, fhir = true WHERE Patient.ts = :ts",
-        setter,
-        deleted);
-    return String.format("%s ON CONFLICT (id) DO %s", insertQuery, updateQuery);
-  }
-
-  private void execute(String query, SqlParameterSource parameters) {
-    jdbcTemplate.execute(query, parameters, new PreparedStatementCallback() {
-      @Override
-      public Object doInPreparedStatement(PreparedStatement ps)
-          throws SQLException, DataAccessException {
-        return ps.executeUpdate();
-      }
-    });
+  public PushDataInterceptor(MappingTableManager manager) {
+    this.manager = manager;
   }
 
   @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
   public void pushCreateData(IBaseResource resource, RequestDetails details) {
     String resourceName = details.getResourceName();
     /* Push to mapping table */
-    IResourceMapper mapper = mapperRegistry.getMapper(resourceName);
-    SqlParameterSource parameters = mapper.mapToTable(resource);
-    if (!resource.getIdElement().hasIdPart()) {
-      List<String> columnNameWithoutId = Arrays.stream(parameters.getParameterNames())
-          .filter(param -> !param.equals("id")).collect(Collectors.toList());
-      execute(insertQuery(resourceName, columnNameWithoutId, false), parameters);
-    } else {
-      execute(upsertQuery(resourceName, List.of(parameters.getParameterNames()), false), parameters);
-    }
+    manager.pushResource(resourceName, resource, false);
     throw new AbortDatabaseOperationException();
   }
 
@@ -87,9 +30,7 @@ public class PushDataInterceptor {
   public void pushUpdateData(IBaseResource resource, RequestDetails details) {
     String resourceName = details.getResourceName();
     /* Push to mapping table */
-    IResourceMapper mapper = mapperRegistry.getMapper(resourceName);
-    SqlParameterSource parameters = mapper.mapToTable(resource);
-    execute(upsertQuery(resourceName, List.of(parameters.getParameterNames()), false), parameters);
+    manager.pushResource(resourceName, resource, false);
     throw new AbortDatabaseOperationException();
   }
 
@@ -97,9 +38,7 @@ public class PushDataInterceptor {
   public void pushDeleteData(IBaseResource resource, RequestDetails details) {
     String resourceName = details.getResourceName();
     /* Push to mapping table */
-    IResourceMapper mapper = mapperRegistry.getMapper(resourceName);
-    SqlParameterSource parameters = mapper.mapToTable(resource);
-    execute(upsertQuery(resourceName, List.of(parameters.getParameterNames()), true), parameters);
+    manager.pushResource(resourceName, resource, true);
     throw new AbortDatabaseOperationException();
   }
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -1,0 +1,69 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.starter.mappers.DatabaseOperation;
+import ca.uhn.fhir.jpa.starter.mappers.IResourceMapper;
+import ca.uhn.fhir.jpa.starter.mappers.ResourceMapperRegistry;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+
+@Component
+@Interceptor
+public class PushDataInterceptor {
+  private String connectionString;
+  private ResourceMapperRegistry mapperRegistry;
+
+  public PushDataInterceptor(@Value("${mappingtable.jdbc}") String connectionString, ResourceMapperRegistry mapperRegistry) {
+    this.connectionString = connectionString;
+    this.mapperRegistry = mapperRegistry;
+  }
+
+  @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
+  public void pushCreateData(IBaseResource resource, RequestDetails details) {
+    /* Push to mapping table */
+    try (Connection conn = DriverManager.getConnection(connectionString)) {
+      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
+      String sql = mapper.mapToTable(resource, DatabaseOperation.INSERT);
+      PreparedStatement stat = conn.prepareStatement(sql);
+      stat.executeUpdate();
+    } catch (SQLException e) {
+    }
+    throw new AbortDatabaseOperationException();
+  }
+
+  @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
+  public void pushUpdateData(IBaseResource resource, RequestDetails details) {
+    /* Push to mapping table */
+    try (Connection conn = DriverManager.getConnection(connectionString)) {
+      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
+      String sql = mapper.mapToTable(resource, DatabaseOperation.UPDATE);
+      PreparedStatement stat = conn.prepareStatement(sql);
+      stat.executeUpdate();
+    } catch (SQLException e) {
+    }
+    throw new AbortDatabaseOperationException();
+  }
+
+  @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_DELETED)
+  public void pushDeleteData(IBaseResource resource, RequestDetails details) {
+    /* Push to mapping table */
+    try (Connection conn = DriverManager.getConnection(connectionString)) {
+      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
+      String sql = mapper.mapToTable(resource, DatabaseOperation.DELETE);
+      PreparedStatement stat = conn.prepareStatement(sql);
+      stat.executeUpdate();
+    } catch (SQLException e) {
+    }
+    throw new AbortDatabaseOperationException();
+  }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -30,7 +30,11 @@ public class PushDataInterceptor {
 
   @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
   public void pushCreateData(IBaseResource resource, RequestDetails details) {
+    IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
+    String sql = mapper.mapToTable(resource, DatabaseOperation.INSERT);
     /* Push to mapping table */
+    /*
+     * 
     try (Connection conn = DriverManager.getConnection(connectionString)) {
       IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
       String sql = mapper.mapToTable(resource, DatabaseOperation.INSERT);
@@ -38,6 +42,8 @@ public class PushDataInterceptor {
       stat.executeUpdate();
     } catch (SQLException e) {
     }
+     */
+    System.out.println(sql);
     throw new AbortDatabaseOperationException();
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/DatabaseOperation.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/DatabaseOperation.java
@@ -1,7 +1,0 @@
-package ca.uhn.fhir.jpa.starter.mappers;
-
-public enum DatabaseOperation {
-  INSERT,
-  UPDATE,
-  DELETE,
-}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/DatabaseOperation.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/DatabaseOperation.java
@@ -1,0 +1,7 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+public enum DatabaseOperation {
+  INSERT,
+  UPDATE,
+  DELETE,
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
@@ -1,14 +1,12 @@
 package ca.uhn.fhir.jpa.starter.mappers;
 
 import java.io.IOException;
-import java.sql.SQLException;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
-import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 public interface IResourceMapper {
-  public IBaseResource mapToResource(SqlRowSet rs) throws SQLException, IOException;
   public String getResourceName();
-  public SqlParameterSource mapToTable(IBaseResource resource);
+  public IBaseResource pullResource(String id, Long version, JdbcTemplate template) throws IOException;
+  public void pushResource(IBaseResource resource, boolean deleted, JdbcTemplate template);
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
@@ -1,13 +1,14 @@
 package ca.uhn.fhir.jpa.starter.mappers;
 
 import java.io.IOException;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
 
 public interface IResourceMapper {
+  public IBaseResource mapToResource(SqlRowSet rs) throws SQLException, IOException;
   public String getResourceName();
-  public IBaseResource mapToResource(ResultSet table) throws SQLException, IOException;
-  public String mapToTable(IBaseResource resource, DatabaseOperation op);
+  public SqlParameterSource mapToTable(IBaseResource resource);
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
@@ -1,0 +1,12 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+public interface IResourceMapper {
+  public String getResourceName();
+  public IBaseResource mapToResource(ResultSet table) throws SQLException;
+  public String mapToTable(IBaseResource resource, DatabaseOperation op);
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.starter.mappers;
 
+import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -7,6 +8,6 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 
 public interface IResourceMapper {
   public String getResourceName();
-  public IBaseResource mapToResource(ResultSet table) throws SQLException;
+  public IBaseResource mapToResource(ResultSet table) throws SQLException, IOException;
   public String mapToTable(IBaseResource resource, DatabaseOperation op);
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/MappingTableManager.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/MappingTableManager.java
@@ -1,0 +1,60 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.util.Pair;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MappingTableManager {
+  private ResourceMapperRegistry registry;
+  private JdbcTemplate jdbcTemplate;
+
+  public MappingTableManager(@Value("${mappingtable.jdbc}") String connectionString,
+  @Value("${mappingtable.username}") String username, @Value("${mappingtable.password}") String password,
+  @Value("${mappingtable.driver}") String driver, ResourceMapperRegistry registry) {
+    DriverManagerDataSource dataSource = new DriverManagerDataSource();
+    dataSource.setUrl(connectionString);
+    dataSource.setUsername(username);
+    dataSource.setPassword(password);
+    dataSource.setDriverClassName(driver);
+    this.jdbcTemplate = new JdbcTemplate(dataSource);
+    this.registry = registry;
+  }
+
+  public List<Pair<IBaseResource, Boolean>> pullResource(String resourceName) throws IOException {
+    String selectStatement = String.format("SELECT id, deleted, version FROM %s WHERE emr = true;", resourceName);
+    SqlRowSet result = jdbcTemplate.queryForRowSet(selectStatement);
+    List<Pair<IBaseResource, Boolean>> ret = new ArrayList<>();
+    while (result.next()) {
+      String id = result.getString("id");
+      Long version = result.getLong("version");
+      Boolean deleted = result.getBoolean("deleted");
+
+      IResourceMapper mapper = registry.getMapper(resourceName);
+      IBaseResource resource = mapper.pullResource(id, version, jdbcTemplate);
+      ret.add(Pair.of(resource, deleted));
+
+      String unsetDirtyStatement = String.format("UPDATE %s SET emr = false WHERE id = ? AND version = ?", resourceName);
+      jdbcTemplate.update(unsetDirtyStatement, id, version);
+    }
+    return ret;
+  }
+
+  public void deleteClean(String resourceName) {
+    String deleteStatement = String.format("DELETE FROM %s WHERE emr = false AND fhir = false", resourceName);
+    jdbcTemplate.update(deleteStatement);
+  }
+
+  public void pushResource(String resourceName, IBaseResource resource, boolean deleted) {
+    IResourceMapper mapper = registry.getMapper(resourceName);
+    mapper.pushResource(resource, deleted, jdbcTemplate);
+  }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
@@ -30,8 +30,8 @@ public class PatientResourceMapper implements IResourceMapper {
 
   @Override
   public IBaseResource pullResource(String id, int version, JdbcTemplate template) throws IOException {
-    String selectStatement = String.format("SELECT * FROM Patient WHERE id = '%s' AND version = %s", id, version);
-    SqlRowSet table = template.queryForRowSet(selectStatement);
+    String selectStatement = "SELECT * FROM Patient WHERE id = ? AND version = ?";
+    SqlRowSet table = template.queryForRowSet(selectStatement, id, version);
     if (!table.next()) {
       // Opimistic locking failed
     }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
@@ -25,7 +25,6 @@ public class PatientResourceMapper implements IResourceMapper {
     this.fhirContext = daoRegistry.getSystemDao().getContext();
   }
 
-
   @Override
   public String getResourceName() {
     return "Patient";
@@ -36,10 +35,7 @@ public class PatientResourceMapper implements IResourceMapper {
     String patientID = table.getString("id");
     String patientGender = table.getString("PatientGender");
     String patientDateOfBirth = table.getString("PatientDateOfBirth");
-    String patientRace = table.getString("PatientRace");
     String patientMaritalStatus = table.getString("PatientMaritalStatus");
-    String patientLanguage = table.getString("PatientLanguage");
-    Double patientPopulationPercentageBelowPoverty = table.getDouble("PatientPopulationPercentageBelowPoverty");
 
     JSONObject jsonObj = new JSONObject();
     jsonObj.put("resourceType", "Patient");
@@ -54,7 +50,7 @@ public class PatientResourceMapper implements IResourceMapper {
     Date lastUpdate = table.getDate("ts");
     metaObject.put("lastUpdated", format.format(lastUpdate));
     jsonObj.put("meta", metaObject);
-    
+
     StringWriter stringWriter = new StringWriter();
     jsonObj.writeJSONString(stringWriter);
     String fhirText = stringWriter.getBuffer().toString();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
@@ -2,7 +2,6 @@ package ca.uhn.fhir.jpa.starter.mappers;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
@@ -30,7 +30,7 @@ public class PatientResourceMapper implements IResourceMapper {
 
   @Override
   public IBaseResource pullResource(String id, int version, JdbcTemplate template) throws IOException {
-    String selectStatement = String.format("SELECT * FROM Patient WHERE id = %s AND version = %s", id, version);
+    String selectStatement = String.format("SELECT * FROM Patient WHERE id = '%s' AND version = %s", id, version);
     SqlRowSet table = template.queryForRowSet(selectStatement);
     if (!table.next()) {
       // Opimistic locking failed

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
@@ -1,0 +1,84 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+import java.io.StringWriter;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonWriter;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r5.model.Patient;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+
+public class PatientResourceMapper implements IResourceMapper {
+  private final FhirContext fhirContext;
+
+  public PatientResourceMapper(DaoRegistry daoRegistry) {
+    this.fhirContext = daoRegistry.getSystemDao().getContext();
+  }
+
+
+  @Override
+  public String getResourceName() {
+    return "Patient";
+  }
+
+  @Override
+  public IBaseResource mapToResource(ResultSet table) throws SQLException {
+    String patientID = table.getString("PatientID");
+    String patientGender = table.getString("PatientGender");
+    String patientDateOfBirth = table.getString("PatientDateOfBirth");
+    String patientRace = table.getString("PatientRace");
+    String patientMaritalStatus = table.getString("PatientMaritalStatus");
+    String patientLanguage = table.getString("PatientLanguage");
+    Double patientPopulationPercentageBelowPoverty = table.getDouble("PatientPopulationPercentageBelowPoverty");
+
+    JsonObject jsonObj = Json.createObjectBuilder()
+        .add("resourceType", "Patient")
+        .add("id", patientID)
+        .add("gender", patientGender)
+        .add("birthDate", patientDateOfBirth.substring(0, 10))
+        .add("maritalStatus", Json.createObjectBuilder().add("text", patientMaritalStatus).build())
+        .add("meta", Json.createObjectBuilder().add("lastUpdated", table.getDate("ts").toString()).build())
+        .build();
+    
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter writer = Json.createWriter(stringWriter);
+    writer.writeObject(jsonObj);
+    writer.close();
+    String fhirText = stringWriter.getBuffer().toString();
+
+    return fhirContext.newJsonParser().parseResource(Patient.class, fhirText);
+  }
+
+  @Override
+  public String mapToTable(IBaseResource resource, DatabaseOperation op) {
+    Patient patient = (Patient) resource;
+    String id = patient.getIdElement() == null ? null : patient.getIdElement().getIdPart();
+    String gender = patient.getGender().getDisplay();
+    String birthDate = patient.getBirthDate().toString();
+    String maritalStatus = patient.getMaritalStatus().getText();
+    String lastUpdated = patient.getMeta().getLastUpdated().toString();
+
+    boolean deleted = op.equals(DatabaseOperation.DELETE);
+
+    if (id == null) {
+      return String.format(
+          "INSERT INTO Patient (PatientGender, PatientDateOfBirth, PatientMaritalStatus) VALUES ('%s', '%s', '%s');",
+          gender, birthDate, maritalStatus);
+    }
+
+    String updateSql = String.format(
+        "UPDATE Patient SET PatientGender = '%s', PatientDateOfBirth = '%s', PatientMaritalStatus = '%s', deleted = %s WHERE PatientID = '%s' AND ts = '%s';", gender, birthDate, maritalStatus, deleted, id, lastUpdated);
+    String insertSql = String.format(
+        "INSERT INTO Patient (PatientID, PatientGender, PatientDateOfBirth, PatientMaritalStatus, deleted) VALUES ('%s', '%s', '%s', '%s', %s);",
+        id, gender, birthDate, maritalStatus, deleted);
+    return String.format(
+        "IF EXISTS (SELECT 1 FROM Patient WHERE PatientID = '%s') BEGIN %s END ELSE BEGIN %s END", id, updateSql, insertSql);
+  }
+  
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
@@ -68,14 +68,14 @@ public class PatientResourceMapper implements IResourceMapper {
 
     if (id == null) {
       return String.format(
-          "INSERT INTO Patient (PatientGender, PatientDateOfBirth, PatientMaritalStatus) VALUES ('%s', '%s', '%s');",
+          "INSERT INTO Patient (PatientGender, PatientDateOfBirth, PatientMaritalStatus, fhir) VALUES ('%s', '%s', '%s', true);",
           gender, birthDate, maritalStatus);
     }
 
     String updateSql = String.format(
-        "UPDATE Patient SET PatientGender = '%s', PatientDateOfBirth = '%s', PatientMaritalStatus = '%s', deleted = %s WHERE PatientID = '%s' AND ts = '%s';", gender, birthDate, maritalStatus, deleted, id, lastUpdated);
+        "UPDATE Patient SET PatientGender = '%s', PatientDateOfBirth = '%s', PatientMaritalStatus = '%s', deleted = %s, fhir = true WHERE PatientID = '%s' AND ts = '%s';", gender, birthDate, maritalStatus, deleted, id, lastUpdated);
     String insertSql = String.format(
-        "INSERT INTO Patient (PatientID, PatientGender, PatientDateOfBirth, PatientMaritalStatus, deleted) VALUES ('%s', '%s', '%s', '%s', %s);",
+        "INSERT INTO Patient (PatientID, PatientGender, PatientDateOfBirth, PatientMaritalStatus, deleted, fhir) VALUES ('%s', '%s', '%s', '%s', %s, true);",
         id, gender, birthDate, maritalStatus, deleted);
     return String.format(
         "IF EXISTS (SELECT 1 FROM Patient WHERE PatientID = '%s') BEGIN %s END ELSE BEGIN %s END", id, updateSql, insertSql);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/ResourceMapperRegistry.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/ResourceMapperRegistry.java
@@ -1,0 +1,31 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+
+@Component
+public class ResourceMapperRegistry {
+  Map<String, IResourceMapper> registry;
+  
+  @Autowired
+  public ResourceMapperRegistry(List<IResourceMapper> mappers) {
+    registry = new HashMap<>();
+    mappers.forEach(mapper -> registry.put(mapper.getResourceName(), mapper));
+  }
+
+  public IResourceMapper getMapper(String resourceName) {
+    if (registry.keySet().contains(resourceName)) {
+      return registry.get(resourceName);
+    }
+    throw new InvalidRequestException(
+        Msg.code(572) + "Unable to process request, this server does not know how to handle resources of type "
+            + resourceName + " - Can handle: " + registry.keySet());
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
     check-location: false
     baselineOnMigrate: true
   datasource:
-    url: 'jdbc:h2:file:./target/database/h2'
+    url: "jdbc:h2:file:./target/database/h2"
     #url: jdbc:h2:mem:test_mem
     username: sa
     password: null
@@ -33,13 +33,13 @@ spring:
       #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
 
       hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
-  #      hibernate.hbm2ddl.auto: update
-  #      hibernate.jdbc.batch_size: 20
-  #      hibernate.cache.use_query_cache: false
-  #      hibernate.cache.use_second_level_cache: false
-  #      hibernate.cache.use_structured_entries: false
-  #      hibernate.cache.use_minimal_puts: false
-  ###    These settings will enable fulltext search with lucene
+      #      hibernate.hbm2ddl.auto: update
+      #      hibernate.jdbc.batch_size: 20
+      #      hibernate.cache.use_query_cache: false
+      #      hibernate.cache.use_second_level_cache: false
+      #      hibernate.cache.use_structured_entries: false
+      #      hibernate.cache.use_minimal_puts: false
+      ###    These settings will enable fulltext search with lucene
       hibernate.search.enabled: false
   #      hibernate.search.backend.type: lucene
   #      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
@@ -120,7 +120,7 @@ hapi:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
       allowed_origin:
-        - '*'
+        - "*"
 
     # Search coordinator thread pool sizes
     search-coord-core-pool-size: 20
@@ -147,7 +147,7 @@ hapi:
     tester:
       home:
         name: Local Tester
-        server_address: 'http://localhost:8080/fhir'
+        server_address: "http://localhost:8080/fhir"
         refuse_to_fetch_third_party_urls: false
         fhir_version: R4
       global:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -195,5 +195,6 @@ hapi:
 
 mappingtable:
   jdbc: jdbc:postgresql://localhost:5432/poc
+  driver: org.postgresql.Driver
   username: postgres
   password: admin

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -194,4 +194,6 @@ hapi:
 #  username: SomeUsername
 
 mappingtable:
-  jdbc: postgresql://localhost:5432/poc
+  jdbc: jdbc:postgresql://localhost:5432/poc
+  username: postgres
+  password: admin

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -192,3 +192,6 @@ hapi:
 #  protocol: 'http'
 #  schema_management_strategy: CREATE
 #  username: SomeUsername
+
+mappingtable:
+  jdbc: postgresql://localhost:5432/poc


### PR DESCRIPTION
* Interceptor랑 ResourceMapper registry 구현
* Patient Resource Mapper 샘플 구현
* 돌려보고 싶으면
로컬에 postgres 띄우고 (connection 정보는 application.yaml에서 수정)
```
CREATE TABLE Patient (
  id VARCHAR(50),
  PatientGender VARCHAR(50),
  PatientDateOfBirth VARCHAR(50),
  PatientRace VARCHAR(50),
  PatientMaritalStatus VARCHAR(50),
  PatientLanguage VARCHAR(50),
  PatientPopulationPercentageBelowPoverty decimal,
  deleted BOOLEAN DEFAULT false,
  emr BOOLEAN DEFAULT false,
  fhir BOOLEAN DEFAULT false,
  ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);

CREATE OR REPLACE FUNCTION update_modified_column()   
RETURNS TRIGGER AS $$
BEGIN
    NEW.ts = now();
    RETURN NEW;   
END;
$$ language 'plpgsql';

CREATE TRIGGER update_modtime BEFORE UPDATE ON Patient FOR EACH ROW EXECUTE PROCEDURE  update_modified_column();

CREATE UNIQUE INDEX idx_patient_id ON Patient(id)
```
이렇게 해놓고 EMR에서 넣듯이 넣거나 CUD에 해당하는 POST요청 실행(?)


해야하는것 -> 
mapping table update 실패시 retry로직
AbortDatabaseException 핸들링
실제 타깃 리소스 3종 ResourceMapper 구현
서버 실행시 위 테이블 생성 자동화
